### PR TITLE
Fixed broken link on Line 133 of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Holy f\*\*\*ing s\*\*\*, how did they do that?
 
 #### Promises
 - [JavaScript Promises: There and Back Again](http://www.html5rocks.com/en/tutorials/es6/promises/) &mdash; detailed introduction to Promises
-- [JavaScript Promises... in Wicked Detail](https://github.com/jaredscheib/resources.git) &mdash; another detailed introduction to Promises
+- [JavaScript Promises... in Wicked Detail](http://www.mattgreer.org/articles/promises-in-wicked-detail/) &mdash; another detailed introduction to Promises
 - [petkaantonov/bluebird](https://github.com/petkaantonov/bluebird) &mdash; a full featured promise library with unmatched performance.
 - [cujojs/when](https://github.com/cujojs/when) &mdash; a solid, fast Promises/A+ and when() implementation, plus other async goodies.
 - [Promises/A+ Spec](http://promisesaplus.com/) &mdash; an open standard for sound, interoperable JavaScript promises—by implementers, for implementers.


### PR DESCRIPTION
I know this is super late and that this document might not be actively used, but I stumbled upon this repo while looking into Promises. I'm a current student at HR25 and doing the Oath micro-sprint :)

Only one change has been made to this document, detailed below:

On Line 133, 'Javascript Promises... in Wicket Detail' was linking to a fork of this exact same repo and not to the actual article itself. It has been replaced with the correct link.